### PR TITLE
Correct a misspelling in the package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@finftraffic-design/coreui-css",
+	"name": "@fintraffic-design/coreui-css",
 	"version": "0.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@finftraffic-design/coreui-css",
+			"name": "@fintraffic-design/coreui-css",
 			"version": "0.0.1",
 			"devDependencies": {
 				"cz-conventional-changelog": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@finftraffic-design/coreui-css",
+	"name": "@fintraffic-design/coreui-css",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",


### PR DESCRIPTION
Tiny thing but thought good to change still 🙈 At least once caused some confusion when making a local symlink of the repo with `npm link` and then trying to use `@fintraffic-design/coreui-css` from own project, and not finding it due to the misspelling